### PR TITLE
Fix false-autoban on score submission

### DIFF
--- a/app/routes/web/error.py
+++ b/app/routes/web/error.py
@@ -20,8 +20,8 @@ def osu_error(
     stacktrace: str = Form(...),
     feedback: Optional[str] = Form(None),
     iltrace: Optional[str] = Form(None),
+    exehash: Optional[str] = Form(None),
     version: str = Form(...),
-    exehash: str = Form(...),
     config: str = Form(...)
 ):
     app.session.logger.warning('\n'.join([

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ attrs==23.1.0
 bcrypt==4.0.1
 boto3==1.28.56
 boto3-type-annotations-with-docs==0.3.1
-botocore==1.31.54
+botocore==1.31.57
 certifi==2023.7.22
 chardet==5.2.0
 charset-normalizer==3.2.0
@@ -40,7 +40,7 @@ redis==5.0.1
 requests==2.31.0
 requests-oauthlib==1.3.1
 rosu-pp-py==0.9.4
-s3transfer==0.6.2
+s3transfer==0.7.0
 scipy==1.11.3
 six==1.16.0
 slider==0.8.0


### PR DESCRIPTION
Fixed this a few days ago, but forgot to update the submodule...
tl;dr there was a bug in the `player_above` function, causing an internal server error, and the client would *instantly* resend the score submission request, resulting in a ban for spamming.