### PR TITLE
Cleanup score submission & fix `#-1` ranks

### DIFF
--- a/app/highlights.py
+++ b/app/highlights.py
@@ -136,7 +136,7 @@ def check_beatmap(
         score.mode,
         '{} ' + f'achieved rank #{beatmap_rank} on' + ' {} ' + f'{f"with {mods} " if mods else ""}<{mode_name}>',
         (player.name, f'http://osu.{config.DOMAIN_NAME}/u/{player.id}'),
-        (score.beatmap.full_name, f'http://osu.{config.DOMAIN_NAME}/b/{score.beatmap.id}')
+        (score.beatmap.full_name, f'http://osu.{config.DOMAIN_NAME}/b/{score.beatmap_id}')
     )
 
 def check_pp(

--- a/app/routes/web/__init__.py
+++ b/app/routes/web/__init__.py
@@ -13,6 +13,7 @@ from . import status
 from . import direct
 from . import error
 from . import title
+from . import login
 from . import maps
 
 router = APIRouter()
@@ -28,4 +29,5 @@ router.include_router(status.router)
 router.include_router(direct.router)
 router.include_router(error.router)
 router.include_router(title.router)
+router.include_router(login.router)
 router.include_router(maps.router)

--- a/app/routes/web/leaderboards.py
+++ b/app/routes/web/leaderboards.py
@@ -503,7 +503,7 @@ def legacy_scores_no_personal_best(
 def legacy_scores_status_change(
     beatmap_hash: str = Query(..., alias='c'),
     beatmap_file: str = Query(..., alias='f'),
-    skip_scores: str = Query(..., alias='s')
+    skip_scores: Optional[str] = Query(None, alias='s')
 ):
     # TODO: /osu-getscores2.php response format is different in some versions
     #       One method would be to check the client version over the cache
@@ -522,7 +522,8 @@ def legacy_scores_status_change(
     submission_status = LegacyStatus.from_database(beatmap.status)
 
     # Status
-    response.append(str(submission_status.value))
+    if submission_status <= SubmissionStatus.Unknown:
+        response.append(str(submission_status.value))
 
     if skip_scores or not beatmap.is_ranked:
         return Response('\n'.join(response))

--- a/app/routes/web/login.py
+++ b/app/routes/web/login.py
@@ -1,0 +1,34 @@
+
+from app.common.database.repositories import users
+
+from datetime import datetime
+from fastapi import (
+    APIRouter,
+    Query
+)
+
+import bcrypt
+import app
+
+router = APIRouter()
+
+@router.get('/osu-login.php')
+def legacy_login(
+    username: str = Query(...),
+    password: str = Query(...)
+):
+    if not (player := users.fetch_by_name(username)):
+        return "0"
+
+    if not bcrypt.checkpw(password.encode(), player.bcrypt.encode()):
+        return "0"
+
+    users.update(player.id, {'latest_activity': datetime.now()})
+
+    app.session.logger.info(
+        f'Player "{player.name}" is about to connect to irc.'
+    )
+
+    # TODO: Open session for irc connection
+
+    return "1"

--- a/app/session.py
+++ b/app/session.py
@@ -3,6 +3,7 @@ from .common.cache.events import EventQueue
 from .common.database import Postgres
 from .common.storage import Storage
 
+from concurrent.futures import ThreadPoolExecutor
 from requests import Session
 from redis import Redis
 
@@ -33,4 +34,5 @@ database = Postgres(
     config.POSTGRES_PORT
 )
 
+executor = ThreadPoolExecutor(max_workers=5)
 storage = Storage()

--- a/utils.py
+++ b/utils.py
@@ -331,6 +331,6 @@ def resize_image(
     image_buffer = io.BytesIO()
 
     img = img.resize((target_width, target_height))
-    img.save(image_buffer, format='PNG' )
+    img.save(image_buffer, format='PNG')
 
     return image_buffer.getvalue()


### PR DESCRIPTION
## Changes

- Fixed `/osu-getscores2.php` for b282.test (https://github.com/osuTitanic/deck/commit/fb60a647751cef0afef4e9542185df04d143eb75)
- Implemented `/osu-login.php` (https://github.com/osuTitanic/deck/commit/402c68b347296238b7a9505d60d6f9d9aad84df0)
- Score submission cleanup & fix for `#-1` ranks (https://github.com/osuTitanic/deck/commit/8001ee2930e74bab588b347562341fa270c42e54)

Before:
![image](https://github.com/osuTitanic/deck/assets/84310095/738bfc5c-fbd8-446f-9d24-01fabd1eb2dc)

After:
![image](https://github.com/osuTitanic/deck/assets/84310095/b7299de9-da9f-47df-9abe-6abc84775058)

Also fixed current map ranks:
![image](https://github.com/osuTitanic/deck/assets/84310095/2a3a06da-cc5d-490f-b7dc-cef8ed25c759)
