### PR TITLE
1.5.2: Fix taiko accuracy calculations & `better_score` checks

### DIFF
--- a/app/objects.py
+++ b/app/objects.py
@@ -134,11 +134,8 @@ class Score:
     @property
     def total_objects(self) -> int:
         """Total amount of passed objects in this score, used for accuracy calculation"""
-        if self.play_mode == GameMode.Osu:
+        if self.play_mode in (GameMode.Osu, GameMode.Taiko):
             return self.c50 + self.c100 + self.c300 + self.cMiss
-
-        elif self.play_mode == GameMode.Taiko:
-            return self.c50 + self.c300 + self.cMiss
 
         elif self.play_mode == GameMode.CatchTheBeat:
             return self.c50 + self.c100 + self.c300 + self.cKatu + self.cMiss

--- a/app/objects.py
+++ b/app/objects.py
@@ -272,7 +272,7 @@ class Score:
         # to total score, if the pp is the same (spin to win)
         better_score = (
             self.pp > self.personal_best.pp
-            if self.pp != self.personal_best.pp
+            if round(self.pp, 6) != round(self.personal_best.pp, 6)
             else self.total_score > self.personal_best.total_score
         )
 

--- a/config.py
+++ b/config.py
@@ -55,4 +55,4 @@ BANCHO_IP = os.environ.get('PUBLIC_BANCHO_IP', None)
 DOMAIN_NAME = os.environ.get('DOMAIN_NAME')
 DATA_PATH = os.path.abspath('.data')
 
-VERSION = '1.5.1'
+VERSION = '1.5.2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psycopg2-binary==2.9.9
 py3rijndael==0.3.3
 python-dotenv==1.0.1
 python-multipart==0.0.9
-redis==5.0.6
+redis==5.0.7
 requests==2.32.3
 sendgrid==6.11.0
 sqlalchemy==2.0.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ requests==2.32.3
 sendgrid==6.11.0
 sqlalchemy==2.0.31
 titanic-pp-py==0.0.6
-uvicorn==0.29.0
+uvicorn==0.30.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ python-multipart==0.0.9
 redis==5.0.6
 requests==2.32.3
 sendgrid==6.11.0
-sqlalchemy==2.0.30
+sqlalchemy==2.0.31
 titanic-pp-py==0.0.6
 uvicorn==0.29.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.34.137
 boto3-type-annotations-with-docs==0.3.1
 fastapi==0.111.0
 geoip2==4.8.0
-pillow==10.3.0
+pillow==10.4.0
 psycopg2-binary==2.9.9
 py3rijndael==0.3.3
 python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ﻿bcrypt==4.1.3
-boto3==1.34.128
+boto3==1.34.132
 boto3-type-annotations-with-docs==0.3.1
 fastapi==0.111.0
 geoip2==4.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ﻿bcrypt==4.1.3
-boto3==1.34.132
+boto3==1.34.137
 boto3-type-annotations-with-docs==0.3.1
 fastapi==0.111.0
 geoip2==4.8.0


### PR DESCRIPTION
## What's Changed

- Updated dependencies
- Taiko accuracy can no longer go over 100%
- You can now spin-to-win and beat your pp plays