### PR TITLE
Don't send NC in `osu-getscores` to clients that interpret it as Taiko

### DIFF
--- a/app/routes/web/leaderboards.py
+++ b/app/routes/web/leaderboards.py
@@ -95,7 +95,7 @@ def resolve_mods(score: DBScore, send_nc: bool = True) -> int:
 
 def client_supports_nc(version: int) -> bool:
     # Nightcore mod was added around b20120623
-    return True if version >= 20120623 else False
+    return True if version >= 20120620 else False
 
 def integer_boolean(parameter: str) -> Callable:
     async def wrapper(request: Request) -> bool:

--- a/app/routes/web/leaderboards.py
+++ b/app/routes/web/leaderboards.py
@@ -94,7 +94,6 @@ def resolve_mods(score: DBScore, send_nc: bool = True) -> int:
     return mods.value
 
 def client_supports_nc(version: int) -> bool:
-    # Nightcore mod was added around b20120623
     return True if version >= 20120620 else False
 
 def integer_boolean(parameter: str) -> Callable:

--- a/app/routes/web/leaderboards.py
+++ b/app/routes/web/leaderboards.py
@@ -102,7 +102,7 @@ def integer_boolean(parameter: str) -> Callable:
         return query == '1'
     return wrapper
 
-def score_string(score: DBScore, index: int, request_version: int = 1, send_nc: bool = True) -> str:
+def score_string(score: DBScore, index: int, send_nc: bool = True, request_version: int = 1) -> str:
     return '|'.join([
         str(score.id),
         str(score.user.name),
@@ -284,7 +284,7 @@ def get_scores(
         )
 
         response.append(
-            score_string(personal_best, index, request_version, send_nc)
+            score_string(personal_best, index, send_nc, request_version)
         )
     else:
         response.append('')
@@ -328,7 +328,7 @@ def get_scores(
 
     for index, score in enumerate(top_scores):
         response.append(
-            score_string(score, index, request_version, send_nc)
+            score_string(score, index, send_nc, request_version)
         )
 
     return Response('\n'.join(response))
@@ -393,7 +393,7 @@ def legacy_scores(
         )
 
         response.append(
-            score_string(personal_best, index, send_nc=send_nc)
+            score_string(personal_best, index, send_nc)
         )
     else:
         response.append('')
@@ -407,7 +407,7 @@ def legacy_scores(
 
     for index, score in enumerate(top_scores):
         response.append(
-            score_string(score, index, send_nc=send_nc)
+            score_string(score, index, send_nc)
         )
 
     return Response('\n'.join(response))
@@ -478,7 +478,7 @@ def legacy_scores_no_ratings(
         )
 
         response.append(
-            score_string(personal_best, index, send_nc=send_nc)
+            score_string(personal_best, index, send_nc)
         )
     else:
         response.append('')
@@ -492,7 +492,7 @@ def legacy_scores_no_ratings(
 
     for index, score in enumerate(top_scores):
         response.append(
-            score_string(score, index, send_nc=send_nc)
+            score_string(score, index, send_nc)
         )
 
     return Response('\n'.join(response))
@@ -560,7 +560,7 @@ def legacy_scores_no_beatmap_data(
         )
 
         response.append(
-            score_string(personal_best, index, send_nc=send_nc)
+            score_string(personal_best, index, send_nc)
         )
     else:
         response.append('')
@@ -574,7 +574,7 @@ def legacy_scores_no_beatmap_data(
 
     for index, score in enumerate(top_scores):
         response.append(
-            score_string(score, index, send_nc=send_nc)
+            score_string(score, index, send_nc)
         )
 
     return Response('\n'.join(response))

--- a/app/routes/web/leaderboards.py
+++ b/app/routes/web/leaderboards.py
@@ -480,6 +480,11 @@ def legacy_scores_no_ratings(
     )
 
     for index, score in enumerate(top_scores):
+        # Don't send NC to clients that interpret NC as Taiko mod
+        if score.mods & Mods.Nightcore:
+            score.mods &= ~Mods.Nightcore
+            score.mods |= Mods.DoubleTime
+
         response.append(
             score_string(score, index)
         )
@@ -561,6 +566,11 @@ def legacy_scores_no_beatmap_data(
     )
 
     for index, score in enumerate(top_scores):
+        # Don't send NC to clients that interpret NC as Taiko mod
+        if score.mods & Mods.Nightcore:
+            score.mods &= ~Mods.Nightcore
+            score.mods |= Mods.DoubleTime
+
         response.append(
             score_string(score, index)
         )
@@ -597,6 +607,11 @@ def legacy_scores_no_personal_best(
     )
 
     for score in top_scores:
+        # Don't send NC to clients that interpret NC as Taiko mod
+        if score.mods & Mods.Nightcore:
+            score.mods &= ~Mods.Nightcore
+            score.mods |= Mods.DoubleTime
+
         response.append(
             score_string_legacy(score)
         )
@@ -637,6 +652,11 @@ def legacy_scores_status_change(
     )
 
     for score in top_scores:
+        # Don't send NC to clients that interpret NC as Taiko mod
+        if score.mods & Mods.Nightcore:
+            score.mods &= ~Mods.Nightcore
+            score.mods |= Mods.DoubleTime
+
         response.append(
             score_string_legacy(score)
         )

--- a/app/routes/web/leaderboards.py
+++ b/app/routes/web/leaderboards.py
@@ -94,7 +94,7 @@ def resolve_mods(score: DBScore, send_nc: bool = True) -> int:
     return mods.value
 
 def client_supports_nc(version: int) -> bool:
-    return True if version >= 20120620 else False
+    return version >= 20120620
 
 def integer_boolean(parameter: str) -> Callable:
     async def wrapper(request: Request) -> bool:


### PR DESCRIPTION
Some 2008 clients that used and read the Taiko mod would get really confused when they saw Nightcore and make the scores appear as Taiko mod, which made viewing these replays unwatchable. The solution is to not send Nightcore from endpoints that these clients used (osu-getscores 2-5). The fix doesn't need to be applied on endpoints 1 and 6 because clients that use them don't read Taiko mod. Titanic doesn't allow Taiko mod scores to be submitted anyways, so working it around that way should be okay.

### 2014 client (native Nightcore)
![2014_nc](https://github.com/user-attachments/assets/505fcd4c-fe21-47bb-9525-b97e47b68a5e)

### 2008 client (before fix)
![b394a_before_fix](https://github.com/user-attachments/assets/ed4babec-9465-4baf-b6da-89d57f86fa1d)

### 2008 client (after fix)
![b394a_fixed](https://github.com/user-attachments/assets/95f3601c-5d21-4bb6-a2a4-315a74269b19)




By the way, I had to manually set DT because NC scores are not stored with DT in the database, is that correct?