### PR TITLE
Remove renderer limitation on benchmark scores

### DIFF
--- a/app/routes/web/benchmark.py
+++ b/app/routes/web/benchmark.py
@@ -42,9 +42,6 @@ def validate_hardware_data(hardware: str) -> dict:
     if 'renderer' not in hardware_dict:
         raise HTTPException(400, "Renderer is required")
 
-    if hardware_dict['renderer'] not in ['OpenGL', 'DirectX']:
-        raise HTTPException(400, "Renderer must be 'OpenGL' or 'DirectX'")
-
     # If only 'renderer' is present, return early without further validation
     if len(hardware_dict) == 1:
         return hardware_dict


### PR DESCRIPTION
Some clients like RetroGecko can specify renderers that aren't part of the vanilla game. Other clients might be using DXVK and might want to expose that to benchmark scores. For example, this field could be `Vulkan` or `D3D11`.

This PR removes the check restricting the renderer to just `OpenGL` and `DirectX` to allow for these types of clients.

*(Yes, I used the GitHub editor for this commit. I did however do my due diligence and checked that this value doesn't resolve to an enum or some other type later down the call stack.)*